### PR TITLE
Added fix for displaying binary use files

### DIFF
--- a/src/main/java/com/horstmann/codecheck/checker/Problem.java
+++ b/src/main/java/com/horstmann/codecheck/checker/Problem.java
@@ -712,7 +712,12 @@ whitespace2 pseudocode2
         for (Map.Entry<Path, byte[]> entry : useFiles.entrySet()) {
             Path path = entry.getKey();
             if (language.isSource(path) && !solutionFiles.containsKey(path) && !annotations.getHidden().contains(path) || isTextFile(path)) {
-                String contents = new String(entry.getValue(), StandardCharsets.UTF_8);
+                String contents;
+                if (Util.isText(entry.getValue())) {
+                    contents = new String(entry.getValue(), StandardCharsets.UTF_8);
+                } else {
+                    contents = "(binary)";
+                }
                 data.useFiles.put(path.toString(), language.isSource(path) ? removePseudoComments(contents) : contents);
             }
         }

--- a/src/main/java/com/horstmann/codecheck/checker/Problem.java
+++ b/src/main/java/com/horstmann/codecheck/checker/Problem.java
@@ -711,10 +711,16 @@ whitespace2 pseudocode2
         data.useFiles = new LinkedHashMap<String, String>();
         for (Map.Entry<Path, byte[]> entry : useFiles.entrySet()) {
             Path path = entry.getKey();
-            if (language.isSource(path) && !solutionFiles.containsKey(path) && !annotations.getHidden().contains(path) || isTextFile(path)) {
-                String contents;
+            String contents;
+            if (language.isSource(path) && !solutionFiles.containsKey(path)
+                    && !annotations.getHidden().contains(path)
+                    || isTextFile(path) || Util.isImageFilename(path.toString())) {
+                        
                 if (Util.isText(entry.getValue())) {
                     contents = new String(entry.getValue(), StandardCharsets.UTF_8);
+                } else if (Util.isImageFilename(path.toString())) {
+                    contents = "data:image/" + Util.extension(path) + ";base64," +
+                                Base64.getEncoder().encodeToString(entry.getValue());
                 } else {
                     contents = "(binary)";
                 }

--- a/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
+++ b/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
@@ -800,7 +800,7 @@ window.addEventListener('load', async function () {
       
       // TODO: Iterate by sort order?
       for (let fileName in setup.useFiles)
-        if (useFileNames.indexOf(fileName) < 0) useFileNames.push(fileName)
+        if (useFileNames.indexOf(fileName) < 0 && !fileName.includes("_outputs/")) useFileNames.push(fileName)
       
       for (let i = 0; i < requiredFileNames.length; i++) 
         appendRequiredFile(requiredFileNames[i], directoryPrefix);      
@@ -808,20 +808,27 @@ window.addEventListener('load', async function () {
     
       for (let i = 0; i < useFileNames.length; i++) {
         let fileName = useFileNames[i]
-        
+        let text = setup.useFiles[fileName].replace(/\r?\n$/, '')
+
         let editorDiv = document.createElement('div')
         editorDiv.classList.add('editor')
-        let text = setup.useFiles[fileName].replace(/\r?\n$/, '')
         editorDiv.textContent = text
         let editor = ace.edit(editorDiv)
-        
         let fileObj = document.createElement('div')
         fileObj.classList.add('codecheckUseFile')
         let filenameDiv = document.createElement('div')
         filenameDiv.classList.add('codecheckFilename')
         filenameDiv.textContent = directoryPrefix + fileName
+
         fileObj.appendChild(filenameDiv)
-        fileObj.appendChild(editorDiv)
+        if (text.includes("data:image/")) {
+          let imgDiv = document.createElement('img')
+          imgDiv.src = text
+          imgDiv.classList.add("img")
+          fileObj.appendChild(imgDiv)
+        } else {
+          fileObj.appendChild(editorDiv)
+        }
         setupAceEditor(editorDiv, editor, fileName, /*readonly*/ true)
         form.appendChild(fileObj)
 

--- a/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
+++ b/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
@@ -800,7 +800,7 @@ window.addEventListener('load', async function () {
       
       // TODO: Iterate by sort order?
       for (let fileName in setup.useFiles)
-        if (useFileNames.indexOf(fileName) < 0 && !fileName.includes("_outputs/")) useFileNames.push(fileName)
+        if (useFileNames.indexOf(fileName) < 0) useFileNames.push(fileName)
       
       for (let i = 0; i < requiredFileNames.length; i++) 
         appendRequiredFile(requiredFileNames[i], directoryPrefix);      


### PR DESCRIPTION
Binary use files currently displayed its contents as nonreadable text. This fix checks if the entry in the useFiles set contains UTF_8-compliant text. If it does, the content is converted to a string, otherwise, the contents will just be "(binary)".

Binary file types not tested for yet:
- .zip
- .png
- .jpg
- .webp