### PR TITLE
Invisible Underscores Fix

### DIFF
--- a/src/main/resources/META-INF/resources/assets/horstmann_codecheck.css
+++ b/src/main/resources/META-INF/resources/assets/horstmann_codecheck.css
@@ -41,14 +41,14 @@
     margin-bottom: 0.5em;
     margin-left: 1.18em;
     font-weight: bold;
-    font-family: "DejaVuSans", sans-serif;
+    font-family: "Mono", sans-serif;
     font-size: 0.85em;
 }
 
 .codecheck-submit-response .header {
     color:#0054a8;
     font-weight: bold;
-    font-family: "DejaVuSans", sans-serif;
+    font-family: "Mono", sans-serif;
     font-size: 1em;
     margin-left: 0em;
 }
@@ -93,7 +93,7 @@
 }
 
 .codecheck-submit-response, .codecheck-submit-response p {
-    font-family: "DejaVuSans", sans-serif;
+    font-family: "Mono", sans-serif;
     font-size: .9em;
     margin-left: 1em;
     margin-bottom: 1em;


### PR DESCRIPTION
This new change seems to work on my end. Hopefully this works on your end too. I think the previous "DejaVuSansMonoSemiCondensed" caused the underscores to be too thin or "invisible" at certain zoom levels.