### PR TITLE
Added button to restore student drafts

### DIFF
--- a/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
+++ b/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
@@ -905,6 +905,15 @@ window.addEventListener('load', async function () {
       })
       submitDiv.appendChild(resetButton);
 
+      let restoreDraftButton = createButton('hc-start', _('Restore Draft'), function() {
+      let draft = JSON.parse(sessionStorage.getItem('studentDraft'))        
+        restoreState(element, draft)
+        element.correct = 0;
+        response.innerHTML = ''
+        if (downloadButton !== undefined) downloadButton.style.display = 'none'
+      })
+      submitDiv.appendChild(restoreDraftButton);
+
       if ('download' in horstmann_config) {
         downloadButton = createButton('hc-start', _('Download'), () => {
           horstmann_config.download('data:application/octet-stream;base64,' + downloadButton.data.zip, downloadButton.data.metadata.ID + '.signed.zip', 'application/octet-stream') 
@@ -975,7 +984,11 @@ window.addEventListener('load', async function () {
         }
       }
     }
-    
+
+  window.addEventListener('input', () => {
+    sessionStorage.setItem('studentDraft', JSON.stringify(getState()))
+  });
+  
     // ..................................................................
     // Start of initElement
       
@@ -1010,4 +1023,5 @@ window.addEventListener('load', async function () {
       initElement(elements[index], { url: `${origin}/checkNJS`, ...data, ...setup })
     }	                
   }
+
 });

--- a/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
+++ b/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
@@ -694,7 +694,7 @@ window.addEventListener('load', async function () {
     let downloadButton = undefined
     let editors = new Map()
 
-    function restoreState(state) { // TODO: Eliminate dummy
+    function restoreState(state) {
       if (state === null || state === undefined) return; // TODO Can it be null???
       let work = state.work
       if ('studentWork' in state) { // TODO: Legacy state

--- a/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
+++ b/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
@@ -694,7 +694,7 @@ window.addEventListener('load', async function () {
     let downloadButton = undefined
     let editors = new Map()
 
-    function restoreState(dummy, state) { // TODO: Eliminate dummy
+    function restoreState(state) { // TODO: Eliminate dummy
       if (state === null || state === undefined) return; // TODO Can it be null???
       let work = state.work
       if ('studentWork' in state) { // TODO: Legacy state
@@ -730,7 +730,8 @@ window.addEventListener('load', async function () {
       if (state.hasOwnProperty('scoreText')) {
         response.textContent = 'Score: ' + state.scoreText
       }
-    }    
+    }
+    window.restoreState = restoreState
 
     function editorFor(fileName, fileSetup) {
       if ('tiles' in fileSetup)
@@ -898,21 +899,12 @@ window.addEventListener('load', async function () {
 
       
       let resetButton = createButton('hc-start', _('Reset'), function() {
-        restoreState(element, initialState)
+        restoreState(initialState)
         element.correct = 0;
         response.innerHTML = ''
         if (downloadButton !== undefined) downloadButton.style.display = 'none'
       })
       submitDiv.appendChild(resetButton);
-
-      let restoreDraftButton = createButton('hc-start', _('Restore Draft'), function() {
-      let draft = JSON.parse(sessionStorage.getItem('studentDraft'))        
-        restoreState(element, draft)
-        element.correct = 0;
-        response.innerHTML = ''
-        if (downloadButton !== undefined) downloadButton.style.display = 'none'
-      })
-      submitDiv.appendChild(restoreDraftButton);
 
       if ('download' in horstmann_config) {
         downloadButton = createButton('hc-start', _('Download'), () => {
@@ -985,9 +977,9 @@ window.addEventListener('load', async function () {
       }
     }
 
-  window.addEventListener('input', () => {
-    sessionStorage.setItem('studentDraft', JSON.stringify(getState()))
-  });
+    window.addEventListener('input', () => {
+      sessionStorage.setItem('studentDraft', JSON.stringify(getState()))
+    });
   
     // ..................................................................
     // Start of initElement
@@ -1023,5 +1015,16 @@ window.addEventListener('load', async function () {
       initElement(elements[index], { url: `${origin}/checkNJS`, ...data, ...setup })
     }	                
   }
+
+  // Restore latest draft
+  try {
+    const draft = JSON.parse(sessionStorage.getItem('studentDraft'));
+    if (draft) {
+      window.restoreState(draft);
+    }
+  } catch (e) {
+    console.warn("Failed to restore draft:", e);
+  }
+
 
 });

--- a/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
+++ b/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
@@ -694,7 +694,7 @@ window.addEventListener('load', async function () {
     let downloadButton = undefined
     let editors = new Map()
 
-    function restoreState(state) {
+    function restoreState(element, state) {
       if (state === null || state === undefined) return; // TODO Can it be null???
       let work = state.work
       if ('studentWork' in state) { // TODO: Legacy state
@@ -899,7 +899,7 @@ window.addEventListener('load', async function () {
 
       
       let resetButton = createButton('hc-start', _('Reset'), function() {
-        restoreState(initialState)
+        restoreState(element, initialState)
         element.correct = 0;
         response.innerHTML = ''
         if (downloadButton !== undefined) downloadButton.style.display = 'none'
@@ -1020,11 +1020,10 @@ window.addEventListener('load', async function () {
   try {
     const draft = JSON.parse(sessionStorage.getItem('studentDraft'));
     if (draft) {
-      window.restoreState(draft);
+      window.restoreState(null, draft);
     }
   } catch (e) {
     console.warn("Failed to restore draft:", e);
   }
-
 
 });


### PR DESCRIPTION
This change is in response to Issue #57: https://github.com/cayhorstmann/codecheck2/issues/57

horstmann_codecheck.js
- Lines 908 - 916: Added button to restore the state of the problem editor to the student's most recent change
- Lines 988 - 990: Added global event listener to save the state of the editor for all inputs (scope of event listener could potentially be reduced if necessary)