### PR TITLE
Improving File Deletion in uploadProblem.html

### DIFF
--- a/src/main/resources/META-INF/resources/assets/uploadProblem.html
+++ b/src/main/resources/META-INF/resources/assets/uploadProblem.html
@@ -46,7 +46,6 @@ document.getElementById('addfile').addEventListener('click',
     document.getElementById('delete' + fileIndex).addEventListener('click',
       function(e) {
         const index = e.target.id.replace('delete', '')
-        console.log("DELETING: filename" + index)
         document.getElementById('filename' + index).setAttribute('value', '')
         document.getElementById('contents' + index).innerHTML = ''
         document.getElementById('contents' + index).value = ''

--- a/src/main/resources/META-INF/resources/assets/uploadProblem.html
+++ b/src/main/resources/META-INF/resources/assets/uploadProblem.html
@@ -44,10 +44,13 @@ document.getElementById('addfile').addEventListener('click',
     addFile.parentNode.insertBefore(fileDiv, addFile)
     
     document.getElementById('delete' + fileIndex).addEventListener('click',
-      function() {
-        document.getElementById('filename' + fileIndex).setAttribute('value', '')
-        document.getElementById('contents' + fileIndex).innerHTML = ''
-        document.getElementById('item' + fileIndex).style.display = 'none'
+      function(e) {
+        const index = e.target.id.replace('delete', '')
+        console.log("DELETING: filename" + index)
+        document.getElementById('filename' + index).setAttribute('value', '')
+        document.getElementById('contents' + index).innerHTML = ''
+        document.getElementById('contents' + index).value = ''
+        document.getElementById('item' + index).style.display = 'none'
     })
 })
 
@@ -67,8 +70,11 @@ document.getElementById("codecheck").addEventListener("click", function() {
     while(document.getElementById("filename" + fileIndex)) {
       const name = document.getElementById("filename" + fileIndex).value
       const content = document.getElementById("contents" + fileIndex).value
-      fileMap.set(name, content)
+      if (content) {
+        fileMap.set(name, content)
+      }
       fileIndex++
+
     }
     fileMap.set("problemID", problemID)
     fileMap.set("editKey", editKey)

--- a/src/main/resources/META-INF/resources/assets/uploadProblem.html
+++ b/src/main/resources/META-INF/resources/assets/uploadProblem.html
@@ -11,8 +11,10 @@
 <a href="https://horstmann.com/codecheck/authoring.html" target="_blank">View User Guide</a>
 </div>
 <div>
+<div id="item1">
 <p>File name: <input id="filename1" name="filename1" size="25" type="text"/></p>
 <p><textarea id="contents1" name="contents1" rows="24" cols="80"></textarea></p>
+</div>
 <div id="addfilecontainer">Need more files? <button id="addfile" type="button">Add file</button></div>
 </div> <br>
 <button id="codecheck" type="button">Submit Changes</button><br><br>
@@ -33,23 +35,21 @@ let editKey = null
 
 document.getElementById('addfile').addEventListener('click',
   function() {
-    fileIndex++
+    const currIndex = ++fileIndex;
     let fileDiv = document.createElement('div')
-    fileDiv.setAttribute('id', 'item' + fileIndex)
-    fileDiv.innerHTML = '<p>File name: <input id="filename' + fileIndex + '" name="filename' + fileIndex 
-            + '" size="25" type="text"/> <button id="delete' + fileIndex 
-            +'" type="button">Delete</button></p><p><textarea id="contents' + fileIndex + '" name="contents' + fileIndex 
+    fileDiv.setAttribute('id', 'item' + currIndex)
+    fileDiv.innerHTML = '<p>File name: <input id="filename' + currIndex + '" name="filename' + currIndex 
+            + '" size="25" type="text"/> <button id="delete' + currIndex 
+            +'" type="button">Delete</button></p><p><textarea id="contents' + currIndex + '" name="contents' + currIndex 
             + '" rows="24" cols="80"/></textarea></p>'
     let addFile = document.getElementById('addfilecontainer')
     addFile.parentNode.insertBefore(fileDiv, addFile)
-    
-    document.getElementById('delete' + fileIndex).addEventListener('click',
-      function(e) {
-        const index = e.target.id.replace('delete', '')
-        document.getElementById('filename' + index).setAttribute('value', '')
-        document.getElementById('contents' + index).innerHTML = ''
-        document.getElementById('contents' + index).value = ''
-        document.getElementById('item' + index).style.display = 'none'
+
+    document.getElementById('delete' + currIndex).addEventListener('click',
+      function() {
+        document.getElementById('contents' + currIndex).innerHTML = ''
+        document.getElementById('contents' + currIndex).value = ''
+        document.getElementById('item' + currIndex).style.display = 'none'
     })
 })
 
@@ -69,7 +69,7 @@ document.getElementById("codecheck").addEventListener("click", function() {
     while(document.getElementById("filename" + fileIndex)) {
       const name = document.getElementById("filename" + fileIndex).value
       const content = document.getElementById("contents" + fileIndex).value
-      if (content) {
+      if (document.getElementById('item' + fileIndex).style.display !== 'none') {
         fileMap.set(name, content)
       }
       fileIndex++


### PR DESCRIPTION
Currently, uploadProblem.html uses the global fileIndex to handle the logic of a delete button. However, deletion works by hiding the contents visually--its ID can still be seen when reading the HTML elements. This makes it impractical to delete files that don't correspond to the current fileIndex, making the deleted file show up in test results and the edit page. 

This change builds upon Issue#58 by extracting the delete file's index and using that as the basis for deletion and setting a check in the /codecheck POST request to properly ignore deleted files.

**uploadProblem.html**
Lines 47-53
EventListener passes the delete button
Corresponding index is extracted from delete button ID
Set all instances of global fileIndex to local index instead
Set file _contents_ to '' 

Lines 72-76
Checks if _contents_ is empty before adding it to the fileMap
