### PR TITLE
Fixed Propagating Inputs

### DIFF
--- a/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
+++ b/src/main/resources/META-INF/resources/assets/horstmann_codecheck.js
@@ -977,8 +977,11 @@ window.addEventListener('load', async function () {
       }
     }
 
+    // Saves the state of a problem to the browser's session storage
     window.addEventListener('input', () => {
-      sessionStorage.setItem('studentDraft', JSON.stringify(getState()))
+      // Key is the URL of an iframe
+      const key = window.location.href;
+      sessionStorage.setItem(key, JSON.stringify(getState()))
     });
   
     // ..................................................................
@@ -1018,7 +1021,8 @@ window.addEventListener('load', async function () {
 
   // Restore latest draft
   try {
-    const draft = JSON.parse(sessionStorage.getItem('studentDraft'));
+    const key = window.location.href;
+    const draft = JSON.parse(sessionStorage.getItem(key));
     if (draft) {
       window.restoreState(null, draft);
     }

--- a/src/main/resources/META-INF/resources/assets/workAssignment.js
+++ b/src/main/resources/META-INF/resources/assets/workAssignment.js
@@ -329,10 +329,11 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   
   if (assignment.isStudent) {
-    if (assignment?.comment !== "") 
+    if (assignment?.comment !== "") {
       document.getElementById('student_comment').textContent = assignment.comment
-    else
+    } else {
       document.getElementById('student_comment_div').style.display = 'none'
+    }
   }
   else if (assignment.saveCommentURL) { // undefined when isStudent
     document.getElementById('instructor_comment').textContent = assignment?.comment
@@ -356,6 +357,7 @@ window.addEventListener('DOMContentLoaded', () => {
     document.getElementById('instructor_comment_div').appendChild(submitButton) 
   } 
   else {
+    document.getElementById('student_comment_div').style.display = 'none'
     document.getElementById('instructor_comment_div').style.display = 'none'
   }
 


### PR DESCRIPTION
This change resolves an issue where CodeCheck assignments will propagate the saved state of a problem to the code editor of other problems.

This is caused by having a singular saved state in session storage that the app pulls from to prevent loss of student progress. As the student progresses to the next problem, the app will apply the saved state to the new problem. 

**horstmann_codecheck.js**
Lines 980 - 984
EventListener that saves the state on any input will use the src of the iframe as the unique key, then store the state in session storage.

Lines 1024-1025
Logic to restore the latest draft will now get the key and use it to get the corresponding draft. 